### PR TITLE
[PUBDEV-2069] Export frame REST call returns job.

### DIFF
--- a/src/ext/components/job-output.coffee
+++ b/src/ext/components/job-output.coffee
@@ -32,6 +32,8 @@ H2O.JobOutput = (_, _go, _job) ->
         'Frame'
       when 'Key<Model>'
         'Model'
+      when 'Key<KeyedVoid>'
+        'Void'
       else
         'Unknown'
 

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -1103,7 +1103,14 @@ H2O.Routines = (_) ->
 
   requestExportFrame = (frameKey, path, opts, go) ->
     _.requestExportFrame frameKey, path, (if opts.overwrite then yes else no), (error, result) ->
-      if error then go error else go null, extendExportFrame result
+      if error
+        go error
+      else
+        _.requestJob result.job.key.name, (error, job) ->
+          if error
+            go error
+          else
+            go null, extendJob job
 
   exportFrame = (frameKey, path, opts={}) ->
     if frameKey and path


### PR DESCRIPTION
The backend rest end-point for exporting a frame returns a job schema.
But flow was expecting a blocking call.

This fix:
 - shows job ui with job progress
 - introduces `Key<KeyedVoid>` for jobs without result in DKV. These jobs
   are shown as type 'Void' in UI.