### PR TITLE
HEXDEV-38: Add Parquet to the list of supported parsers

### DIFF
--- a/src/ext/components/parse-input.coffee
+++ b/src/ext/components/parse-input.coffee
@@ -1,6 +1,6 @@
 MaxItemsPerPage = 15
 
-parseTypes = map [ 'AUTO', 'ARFF', 'XLS', 'XLSX', 'CSV', 'SVMLight', 'ORC', 'AVRO' ], (type) -> type: type, caption: type
+parseTypes = map [ 'AUTO', 'ARFF', 'XLS', 'XLSX', 'CSV', 'SVMLight', 'ORC', 'AVRO', 'PARQUET' ], (type) -> type: type, caption: type
 
 parseDelimiters = do ->
   whitespaceSeparators = [


### PR DESCRIPTION
Enables Parquet support for Flow: https://github.com/h2oai/h2o-3/pull/136