### PR TITLE
use relative reference for Google fonts

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -13,7 +13,7 @@ html(lang='en')
     link(rel='stylesheet', href='css/flow-lib.css', type='text/css')
     link(rel='stylesheet', href='css/flow.css', type='text/css')
     link(rel='stylesheet', href='css/scala-editor.css', type='text/css')
-    link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic|Source+Code+Pro:400,600', type='text/css')
+    link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic|Source+Code+Pro:400,600', type='text/css')
     link(rel='stylesheet', href='custom/custom.css', type='text/css')
 
     //- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries


### PR DESCRIPTION
This PR fixes the mixed content error when running with TLS.