### PR TITLE
add markup for roomscale scatterplot

### DIFF
--- a/src/ext/components/h2o.jade
+++ b/src/ext/components/h2o.jade
@@ -41,6 +41,12 @@ script(type="text/html" id="flow-partial-dependence-input")
 script(type="text/html" id="flow-partial-dependence-output")
   include partial-dependence-output.jade
 
+script(type="text/html" id="flow-roomscale-scatterplot-input")
+  include roomscale-scatterplot-input.jade
+
+script(type="text/html" id="flow-roomscale-scatterplot-output")
+  include roomscale-scatterplot-output.jade
+
 script(type="text/html" id="flow-parse-raw-input")
   include parse-input.jade
 

--- a/src/ext/components/roomscale-scatterplot-input.jade
+++ b/src/ext/components/roomscale-scatterplot-input.jade
@@ -1,0 +1,41 @@
+.flow-widget
+  +subtitle('Roomscale Scatterplot', 'link')
+
+  // ko if:exception
+  div(data-bind="template: { name:'flow-failure', data:exception }")
+  // /ko
+
+  table.flow-form
+    tbody
+      tr
+        th
+          label Frame:
+        td(colspan='2')
+          select(data-bind="options:frames, value:selectedFrame, optionsCaption:'(Select)', event:{ change:updateColumns}")
+      tr
+        th
+          label X-Variable:
+        td(colspan='2')
+          select(data-bind="options:columns, value:selectedXVariable, optionsCaption:'(Select)'")
+      tr
+        th
+          label Y-Variable:
+        td(colspan='2')
+          select(data-bind="options:columns, value:selectedYVariable, optionsCaption:'(Select)'")
+      tr
+        th
+          label Z-Variable:
+        td(colspan='2')
+          select(data-bind="options:columns, value:selectedZVariable, optionsCaption:'(Select)'")
+      tr
+        th
+          label Color-Variable:
+        td(colspan='2')
+          select(data-bind="options:columns, value:selectedColorVariable, optionsCaption:'(Select)'")
+      tr
+        th
+          label Actions:
+        td
+          button.flow-button(type='button' data-bind='click:compute, enable:canCompute')
+            i.fa.fa-link
+            span Compute

--- a/src/ext/components/roomscale-scatterplot-output.jade
+++ b/src/ext/components/roomscale-scatterplot-output.jade
@@ -1,0 +1,7 @@
+.flow-widget
+  +subtitle('Roomscale Scatterplot', 'table')
+
+  .flow-margin-after
+  
+  div
+    a(data-bind="href:plotUrl") plotUrl


### PR DESCRIPTION
This PR add markup for the roomscale scatterplot

companion `drift` PR that adds the corresponding `Javascript` logic: https://github.com/micahstubbs/drift/pull/122

![screen shot 2017-02-07 at 4 39 15 pm](https://cloud.githubusercontent.com/assets/2119400/22718352/c4eff88c-ed54-11e6-95ac-8359899ff91c.png)
![screen shot 2017-02-07 at 4 39 28 pm](https://cloud.githubusercontent.com/assets/2119400/22718353/c7b4479e-ed54-11e6-9a6c-8087a5e8c847.png)
![screen shot 2017-02-07 at 4 39 48 pm](https://cloud.githubusercontent.com/assets/2119400/22718355/c9c6b936-ed54-11e6-8dff-103236f9873c.png)
