### PR TITLE
PUBDEV-4229 Inspection of model predictions can come from training fr…

### DIFF
--- a/src/ext/components/predict-output.coffee
+++ b/src/ext/components/predict-output.coffee
@@ -1,7 +1,8 @@
-H2O.PredictOutput = (_, _go, modelKey, frameKey, predictionFrameKey, prediction) ->
+H2O.PredictOutput = (_, _go, modelKey, frameKey, predictionFrame, prediction) ->
   if prediction
     { frame, model } = prediction
 
+  predictionFrameKey = predictionFrame.name
   _plots = signals []
   _canInspect = if prediction.__meta then yes else no
 

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -699,7 +699,7 @@ H2O.Routines = (_) ->
     modelKey = result.model.name
     frameKey = result.frame?.name
     prediction = head result.model_metrics
-    predictionFrame = result.predictions_frame
+    predictionFrame = if result.predictions_frame is null then result.frame? else result.predictions_frame
 
     inspections = {}
     if prediction
@@ -709,7 +709,7 @@ H2O.Routines = (_) ->
       inspectObject inspections, 'Prediction', "getPrediction model: #{stringify modelKey}, frame: #{stringify frameKey}", { prediction_frame: predictionFrame }
 
     inspect_ prediction, inspections
-    render_ prediction, H2O.PredictOutput, modelKey, frameKey, predictionFrame.name, prediction
+    render_ prediction, H2O.PredictOutput, modelKey, frameKey, predictionFrame, prediction
 
   inspectFrameColumns = (tableLabel, frameKey, frame, frameColumns) -> ->
     attrs = [


### PR DESCRIPTION
…ame or pred frame

After prediction on a Frame is done,the Inspect button calls:
  inspect getPrediction model: "glm-0e5d9a55-e702-474f-9af8-ba27bad8c5a0", frame: "covtype.hex"
But covtype.hex is the same frame that we trained and then scored on. So prediction_frame is null. This fix uses covtype as the predictionframe that is passed to H2O.PredictOutput

phantomjs test pass on my local machine