### PR TITLE
[PUBDEV-4497] Use info log as default

### DIFF
--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -1738,7 +1738,7 @@ H2O.Routines = (_) ->
           else
             go null, extendLogFile cloud, nodeIpPort, fileType, logFile
 
-  getLogFile = (nodeIpPort="self", fileType='warn') ->
+  getLogFile = (nodeIpPort="self", fileType='info') ->
     _fork requestLogFile, nodeIpPort, fileType
 
   requestNetworkTest = (go) ->


### PR DESCRIPTION
I set in previous change default log to warn, however info makes more sense so reverting back