### PR TITLE
[PUBDEV-3824]: Grayed out download buttons for formats not supported 

### DIFF
--- a/src/ext/components/model-output.coffee
+++ b/src/ext/components/model-output.coffee
@@ -781,6 +781,8 @@ H2O.ModelOutput = (_, _go, _model, refresh) ->
     plots: _plots
     inputParameters: _inputParameters
     isExpanded: _isExpanded
+    havePojo: _model.have_pojo
+    haveMojo: _model.have_mojo
     toggle: toggle
     cloneModel: cloneModel
     predict: predict

--- a/src/ext/components/model-output.jade
+++ b/src/ext/components/model-output.jade
@@ -29,8 +29,14 @@
 
             +button('Predict&hellip;', 'bolt', 'predict')
             //- +button('Clone this model&hellip;', 'copy', 'cloneModel')
-            +button('Download POJO', 'download', 'downloadPojo')
-            +button('Download Model Deployment Package (MOJO)', 'download', 'downloadMojo')
+            button.flow-button(type='button' data-bind="click: downloadPojo, enable: $data.havePojo")
+              i.fa.fa-download
+              span
+              | Download POJO
+            button.flow-button(type='button' data-bind="click: downloadMojo, enable: $data.haveMojo")
+              i.fa.fa-download
+              span
+              | Download Model Deployment Package (MOJO)
             +button('Export', 'save', 'exportModel')
             +button('Inspect', 'list', 'inspect')
             +button('Delete', 'trash-o', 'deleteModel')
@@ -91,13 +97,17 @@
           // /ko
   // /ko
 
-  h4(data-bind='collapse:false') Preview POJO
-  div
-    // ko ifnot:isPojoLoaded
-    +button('Preview POJO', 'code', 'previewPojo')
-    // /ko
-    // ko if:isPojoLoaded
-    div(data-bind='html:pojoPreview')
-    // /ko
+  div(data-bind='visible: $data.havePojo')
+    h4(data-bind='collapse:false') Preview POJO
+    div
+      // ko ifnot:isPojoLoaded
+      button.flow-button(type='button' data-bind="click: previewPojo, enable: $data.havePojo")
+        i.fa.fa-code
+        span
+        | Preview POJO
+      // /ko
+      // ko if:isPojoLoaded
+      div(data-bind='html:pojoPreview')
+      // /ko
 
   // /ko


### PR DESCRIPTION
The download POJO/MOJO buttons are grayed out, if given model does not support export to requested format. Also the Preview POJO button is grayed out, if export to POJO is not possible. 

~~Requires changes from https://github.com/h2oai/h2o-3/pull/1489 which are not yet merged to master.~~