### PR TITLE
[PUBDEV-5031] Exporting notebook should include ContextPath

### DIFF
--- a/build/js/flow.js
+++ b/build/js/flow.js
@@ -7427,7 +7427,7 @@
         exportNotebook = function () {
             var remoteName;
             if (remoteName = _remoteName()) {
-                return window.open('/3/NodePersistentStorage.bin/notebook/' + remoteName, '_blank');
+                return window.open(window.Flow.ContextPath + '3/NodePersistentStorage.bin/notebook/' + remoteName, '_blank');
             } else {
                 return _.alert('Please save this notebook before exporting.');
             }


### PR DESCRIPTION
Exporting a notebook in H2O Flow fails with a 404 Not Found when context_path is set in H2O launch options. The url for exporting notebook does contain the context_path as part of the URL.