### PR TITLE
[PUBDEV-5344] Moved Run AutoML to the top of the Model menu.

### DIFF
--- a/src/core/components/notebook.coffee
+++ b/src/core/components/notebook.coffee
@@ -585,16 +585,16 @@ Flow.Notebook = (_, _renderers) ->
     menuCell = [menuCell..., menuCellSW...]
 
   initializeMenus = (builder) ->
-    modelMenuItems = map(builder, (builder) ->
-      createMenuItem "#{ builder.algo_full_name }...", executeCommand "buildModel #{stringify builder.algo}"
-    ).concat [
+    modelMenuItems = [createMenuItem('Run AutoML...', executeCommand 'runAutoML'), menuDivider]
+    modelMenuItems = modelMenuItems.concat map(builder, (builder) ->
+      createMenuItem("#{ builder.algo_full_name }...", executeCommand "buildModel #{stringify builder.algo}")
+    )
+    modelMenuItems = modelMenuItems.concat [
       menuDivider
       createMenuItem 'List All Models', executeCommand 'getModels'
       createMenuItem 'List Grid Search Results', executeCommand 'getGrids'
       createMenuItem 'Import Model...', executeCommand 'importModel'
       createMenuItem 'Export Model...', executeCommand 'exportModel'
-      menuDivider
-      createMenuItem 'Run AutoML...', executeCommand 'runAutoML'
     ]
 
     [

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -34,12 +34,12 @@ _assistance =
   getJobs:
     description: 'Get a list of jobs running in H<sub>2</sub>O'
     icon: 'tasks'
-  buildModel:
-    description: 'Build a model'
-    icon: 'cube'
   runAutoML:
     description: 'Automatically train and tune many models'
     icon: 'sitemap'
+  buildModel:
+    description: 'Build a model'
+    icon: 'cube'
   importModel:
     description: 'Import a saved model'
     icon: 'cube'


### PR DESCRIPTION
Moved **Run AutoML** to the top of the **Model** menu. Due to consistency, I think the **runAutoML** should be **before buildModel** in **Assistance** as well. Please let me know, if this is ok. Screens:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/29674210/36659597-45eab838-1ad5-11e8-8f22-b82550b5175e.png">
<img width="453" alt="image" src="https://user-images.githubusercontent.com/29674210/36659606-4cbd44b4-1ad5-11e8-934d-ce2f825a1974.png">
