### PR TITLE
[PUBDEV-3978] .flow-plot has max-height of 500px

### DIFF
--- a/src/flow.styl
+++ b/src/flow.styl
@@ -563,6 +563,8 @@ table
 .flow-plot
   monospace()
   overflow visible
+  max-height: 500px
+  overflow: auto
   margin-bottom 20px
   table
     // margin 10px 0 20px 0


### PR DESCRIPTION
This PR sets maximum height for for example `Output - Scoring History` or `User Feedback` in AutoML. If the height is exceeded a scrollbar is shown. Checked on IE as well

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/29674210/36680308-ad978124-1b15-11e8-9cd8-08f9015f7943.png">
