### PR TITLE
Add Import SQL Table widget

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -63,6 +63,7 @@
     "node-uuid": "~1.4.1",
     "diecut": "~0.0.1",
     "highlightjs": "~8.5.0",
-    "codemirror": "~5.12.0"
+    "codemirror": "~5.12.0",
+    "aes-js": "~3.1.0"
   }
 }

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -67,6 +67,7 @@ config =
       'lib/codemirror/lib/codemirror.js'
       'lib/codemirror/mode/clike/clike.js'
       'lib/codemirror/addon/edit/matchbrackets.js'
+      'lib/aes-js/index.js'
 
     ]
     css: [

--- a/src/core/components/notebook.coffee
+++ b/src/core/components/notebook.coffee
@@ -619,6 +619,7 @@ Flow.Notebook = (_, _renderers) ->
       createMenu 'Data', [
         createMenuItem 'Import Files...', executeCommand 'importFiles'
         createMenuItem 'Import SQL Table...', executeCommand 'importSqlTable'
+        createMenuItem 'Import BiqQuery Table...', executeCommand 'importBqTable'
         createMenuItem 'Upload File...', uploadFile
         createMenuItem 'Split Frame...', executeCommand 'splitFrame'
         createMenuItem 'Merge Frames...', executeCommand 'mergeFrames'

--- a/src/core/components/notebook.coffee
+++ b/src/core/components/notebook.coffee
@@ -48,10 +48,13 @@ Flow.Notebook = (_, _renderers) ->
       else
         _.scalaIntpId response.session_id
 
+  sanitizeCellInput = (cellInput) ->
+    cellInput.replace /\"password\":\"[^\"]*\"/g, "\"password\":\"\""
+
   serialize = ->
     cells = for cell in _cells()
       type: cell.type()
-      input: cell.input()
+      input: sanitizeCellInput cell.input()
 
     version: '1.0.0'
     cells: cells

--- a/src/core/components/notebook.coffee
+++ b/src/core/components/notebook.coffee
@@ -619,7 +619,6 @@ Flow.Notebook = (_, _renderers) ->
       createMenu 'Data', [
         createMenuItem 'Import Files...', executeCommand 'importFiles'
         createMenuItem 'Import SQL Table...', executeCommand 'importSqlTable'
-        createMenuItem 'Import BiqQuery Table...', executeCommand 'importBqTable'
         createMenuItem 'Upload File...', uploadFile
         createMenuItem 'Split Frame...', executeCommand 'splitFrame'
         createMenuItem 'Merge Frames...', executeCommand 'mergeFrames'

--- a/src/core/components/notebook.coffee
+++ b/src/core/components/notebook.coffee
@@ -618,6 +618,7 @@ Flow.Notebook = (_, _renderers) ->
     ,
       createMenu 'Data', [
         createMenuItem 'Import Files...', executeCommand 'importFiles'
+        createMenuItem 'Import SQL Table...', executeCommand 'importSqlTable'
         createMenuItem 'Upload File...', uploadFile
         createMenuItem 'Split Frame...', executeCommand 'splitFrame'
         createMenuItem 'Merge Frames...', executeCommand 'mergeFrames'

--- a/src/ext/components/h2o.jade
+++ b/src/ext/components/h2o.jade
@@ -65,6 +65,9 @@ script(type="text/html" id="flow-import-files")
 script(type="text/html" id="flow-import-sql-table-input")
   include import-sql-table-input.jade
 
+script(type="text/html" id="flow-import-bq-table-input")
+  include import-bq-table-input.jade
+
 script(type="text/html" id="flow-import-sql-table-output")
   include import-sql-table-output.jade
 

--- a/src/ext/components/h2o.jade
+++ b/src/ext/components/h2o.jade
@@ -62,6 +62,12 @@ script(type="text/html" id="flow-import-files-output")
 script(type="text/html" id="flow-import-files")
   include import-files.jade
 
+script(type="text/html" id="flow-import-sql-table-input")
+  include import-sql-table-input.jade
+
+script(type="text/html" id="flow-import-sql-table-output")
+  include import-sql-table-output.jade
+
 script(type="text/html" id="flow-checkbox-model-parameter")
   include model-parameter-checkbox.jade
 

--- a/src/ext/components/import-bq-table-input.coffee
+++ b/src/ext/components/import-bq-table-input.coffee
@@ -1,0 +1,28 @@
+H2O.ImportBqTableInput = (_, _go) ->
+
+  _specifiedProject = signal ''
+  _specifiedDataset = signal ''
+  _specifiedTable = signal ''
+  _specifiedColumns = signal ''
+  _exception = signal ''
+  _hasErrorMessage = lift _exception, (exception) -> if exception then yes else no
+
+  importSqlTableAction = ->
+    opt =
+       connection_url: "jdbc:bigquery://https://www.googleapis.com/bigquery/v2;OAuthType=3;ProjectId=#{ _specifiedProject() };"
+       table: "`#{ _specifiedDataset() }`.#{ _specifiedTable() }"
+       columns: _specifiedColumns()
+       username: ''
+       password: ''
+    _.insertAndExecuteCell 'cs', "importSqlTable #{ stringify opt }"
+
+  defer _go
+
+  hasErrorMessage: _hasErrorMessage #XXX obsolete
+  specifiedProject: _specifiedProject
+  specifiedDataset: _specifiedDataset
+  specifiedTable: _specifiedTable
+  specifiedColumns: _specifiedColumns
+  exception: _exception
+  importSqlTableAction: importSqlTableAction
+  template: 'flow-import-bq-table-input'

--- a/src/ext/components/import-bq-table-input.jade
+++ b/src/ext/components/import-bq-table-input.jade
@@ -1,0 +1,53 @@
+.flow-widget
+  h3.flow-hint
+    i.fa.fa-table
+    | Import BigQuery Table
+  table.flow-form
+    tbody
+      tr
+        th(width='125') Project:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedProject" placeholder='Enter a BigQuery project ID.')
+      tr
+        th(width='125') Dataset:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedDataset" placeholder='Enter a BigQuery dataset name.')
+      tr
+        th(width='125') Table:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedTable" placeholder='Enter a BigQuery table name.')
+      tr
+        th(width='125') Columns:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedColumns" placeholder='Enter a comma-separated list of column names to import. Default is to import all columns.')
+
+      // ko if:hasErrorMessage
+      tr
+        th &nbsp;
+        td(data-bind='text:exception')
+      // /ko
+
+      tr.flow-actions
+        th Actions:
+        td
+          button.flow-button(type='button' data-bind='click:importSqlTableAction')
+            i.fa.fa-cloud-upload
+            | Import
+// /ko
+

--- a/src/ext/components/import-sql-table-input.coffee
+++ b/src/ext/components/import-sql-table-input.coffee
@@ -1,5 +1,4 @@
 H2O.ImportSqlTableInput = (_, _go) ->
-
   _specifiedUrl = signal ''
   _specifiedTable = signal ''
   _specifiedColumns = signal ''
@@ -9,12 +8,14 @@ H2O.ImportSqlTableInput = (_, _go) ->
   _hasErrorMessage = lift _exception, (exception) -> if exception then yes else no
 
   importSqlTableAction = ->
+    encryptedPassword = H2O.Util.encryptPassword _specifiedPassword()
+
     opt =
        connection_url: _specifiedUrl()
        table: _specifiedTable()
        columns: _specifiedColumns()
        username: _specifiedUsername()
-       password: _specifiedPassword()
+       password: encryptedPassword
     _.insertAndExecuteCell 'cs', "importSqlTable #{ stringify opt }"
 
   defer _go

--- a/src/ext/components/import-sql-table-input.coffee
+++ b/src/ext/components/import-sql-table-input.coffee
@@ -1,0 +1,30 @@
+H2O.ImportSqlTableInput = (_, _go) ->
+
+  _specifiedUrl = signal ''
+  _specifiedTable = signal ''
+  _specifiedColumns = signal ''
+  _specifiedUsername = signal ''
+  _specifiedPassword = signal ''
+  _exception = signal ''
+  _hasErrorMessage = lift _exception, (exception) -> if exception then yes else no
+
+  importSqlTableAction = ->
+    opt =
+       connection_url: _specifiedUrl()
+       table: _specifiedTable()
+       columns: _specifiedColumns()
+       username: _specifiedUsername()
+       password: _specifiedPassword()
+    _.insertAndExecuteCell 'cs', "importSqlTable #{ stringify opt }"
+
+  defer _go
+
+  hasErrorMessage: _hasErrorMessage #XXX obsolete
+  specifiedUrl: _specifiedUrl
+  specifiedTable: _specifiedTable
+  specifiedColumns: _specifiedColumns
+  specifiedUsername: _specifiedUsername
+  specifiedPassword: _specifiedPassword
+  exception: _exception
+  importSqlTableAction: importSqlTableAction
+  template: 'flow-import-sql-table-input'

--- a/src/ext/components/import-sql-table-input.jade
+++ b/src/ext/components/import-sql-table-input.jade
@@ -43,7 +43,7 @@
             tbody
               tr
                 td.flow-wide
-                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedPassword" placeholder='Enter a password for SQL server.')
+                  input.flow-textbox(type='password' style='width:100%' data-bind="value:specifiedPassword" placeholder='Enter a password for SQL server.')
 
       // ko if:hasErrorMessage
       tr

--- a/src/ext/components/import-sql-table-input.jade
+++ b/src/ext/components/import-sql-table-input.jade
@@ -1,0 +1,61 @@
+.flow-widget
+  h3.flow-hint
+    i.fa.fa-table
+    | Import SQL Table
+  table.flow-form
+    tbody
+      tr
+        th(width='125') Connection URL:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedUrl" placeholder='Enter URL of the SQL database as specified by the JDBC.')
+      tr
+        th(width='125') Table:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedTable" placeholder='Enter a name of SQL table.')
+      tr
+        th(width='125') Columns:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedColumns" placeholder='Enter a comma-separated list of column names to import. Default is to import all columns.')
+      tr
+        th(width='125') Username:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedUsername" placeholder='Enter a username for SQL server.')
+      tr
+        th(width='125') Password:
+        td
+          table(width='100%')
+            tbody
+              tr
+                td.flow-wide
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedPassword" placeholder='Enter a password for SQL server.')
+
+      // ko if:hasErrorMessage
+      tr
+        th &nbsp;
+        td(data-bind='text:exception')
+      // /ko
+
+      tr.flow-actions
+        th Actions:
+        td
+          button.flow-button(type='button' data-bind='click:importSqlTableAction')
+            i.fa.fa-cloud-upload
+            | Import
+// /ko
+

--- a/src/ext/components/import-sql-table-output.coffee
+++ b/src/ext/components/import-sql-table-output.coffee
@@ -1,5 +1,10 @@
 H2O.ImportSqlTableOutput = (_, _go, _importResults) ->
-  viewData = -> _.insertAndExecuteCell 'cs', "getFrameSummary #{ stringify _importResults.dest.name }"
+  viewData = ->
+    if _importResults.status == 'DONE'
+      _.insertAndExecuteCell 'cs', "getFrameSummary #{ stringify _importResults.dest.name }"
+    else
+      _.insertAndExecuteCell 'cs', "getJob #{ stringify _importResults.key.name }"
+
   defer _go
   viewData: viewData
   template: 'flow-import-sql-table-output'

--- a/src/ext/components/import-sql-table-output.coffee
+++ b/src/ext/components/import-sql-table-output.coffee
@@ -1,0 +1,6 @@
+H2O.ImportSqlTableOutput = (_, _go, _importResults) ->
+  viewData = -> _.insertAndExecuteCell 'cs', "getFrameSummary #{ stringify _importResults.dest.name }"
+  defer _go
+  viewData: viewData
+  template: 'flow-import-sql-table-output'
+

--- a/src/ext/components/import-sql-table-output.jade
+++ b/src/ext/components/import-sql-table-output.jade
@@ -1,6 +1,6 @@
 .flow-widget
-  +subtitle('Table Imported', 'save')
-  blockquote The specified SQL Table was imported successfully.
+  +subtitle('Table Import', 'save')
+  blockquote The specified SQL Table is being imported.
   button.flow-button(type='button' data-bind='click:viewData')
     i.fa.fa-table
     span View

--- a/src/ext/components/import-sql-table-output.jade
+++ b/src/ext/components/import-sql-table-output.jade
@@ -1,0 +1,7 @@
+.flow-widget
+  +subtitle('Table Imported', 'save')
+  blockquote The specified SQL Table was imported successfully.
+  button.flow-button(type='button' data-bind='click:viewData')
+    i.fa.fa-table
+    span View Data
+

--- a/src/ext/components/import-sql-table-output.jade
+++ b/src/ext/components/import-sql-table-output.jade
@@ -3,5 +3,6 @@
   blockquote The specified SQL Table was imported successfully.
   button.flow-button(type='button' data-bind='click:viewData')
     i.fa.fa-table
-    span View Data
+    span View
+
 

--- a/src/ext/modules/application-context.coffee
+++ b/src/ext/modules/application-context.coffee
@@ -4,6 +4,7 @@ H2O.ApplicationContext = (_) ->
   _.requestSplitFrame = do slot
   _.requestImportFile = do slot
   _.requestImportFiles = do slot
+  _.requestImportSqlTable = do slot
   _.requestParseFiles = do slot
   _.requestInspect = do slot
   _.requestParseSetup = do slot

--- a/src/ext/modules/proxy.coffee
+++ b/src/ext/modules/proxy.coffee
@@ -247,6 +247,16 @@ H2O.Proxy = (_) ->
     opts = path: encodeURIComponent path
     requestWithOpts '/3/ImportFiles', opts, go
 
+  requestImportSqlTable = (args, go) ->
+    opts =
+      connection_url: args.connection_url
+      table: args.table
+      username: args.username
+      password: args.password
+    if args.columns != ''
+      opts.columns = args.columns
+    doPost '/99/ImportSQLTable', opts, go
+
   requestParseSetup = (sourceKeys, go) ->
     opts =
       source_frames: encodeArrayForPost sourceKeys
@@ -624,6 +634,7 @@ H2O.Proxy = (_) ->
   link _.requestFileGlob, requestFileGlob
   link _.requestImportFiles, requestImportFiles
   link _.requestImportFile, requestImportFile
+  link _.requestImportSqlTable, requestImportSqlTable
   link _.requestParseSetup, requestParseSetup
   link _.requestParseSetupPreview, requestParseSetupPreview
   link _.requestParseFiles, requestParseFiles

--- a/src/ext/modules/proxy.coffee
+++ b/src/ext/modules/proxy.coffee
@@ -248,11 +248,12 @@ H2O.Proxy = (_) ->
     requestWithOpts '/3/ImportFiles', opts, go
 
   requestImportSqlTable = (args, go) ->
+    decryptedPassword = H2O.Util.decryptPassword args.password
     opts =
       connection_url: args.connection_url
       table: args.table
       username: args.username
-      password: args.password
+      password: decryptedPassword
     if args.columns != ''
       opts.columns = args.columns
     doPost '/99/ImportSQLTable', opts, go

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -16,6 +16,9 @@ _assistance =
   importSqlTable:
     description: 'Import SQL table into H<sub>2</sub>O'
     icon: 'table'
+  importBqTable:
+    description: 'Import BigQuery table into H<sub>2</sub>O'
+    icon: 'table'
   getFrames:
     description: 'Get a list of frames in H<sub>2</sub>O'
     icon: 'table'
@@ -1512,6 +1515,9 @@ H2O.Routines = (_) ->
       else
         assist importSqlTable
 
+  importBqTable = ->
+    assist importBqTable
+
   extendParseSetupResults = (args, parseSetupResults) ->
     render_ parseSetupResults, H2O.SetupParseOutput, args, parseSetupResults
 
@@ -1918,6 +1924,8 @@ H2O.Routines = (_) ->
           _fork proceed, H2O.ImportFilesInput, []
         when importSqlTable
           _fork proceed, H2O.ImportSqlTableInput, args
+        when importBqTable
+          _fork proceed, H2O.ImportBqTableInput, args
         when buildModel
           _fork proceed, H2O.ModelInput, args
         when runAutoML
@@ -2011,6 +2019,7 @@ H2O.Routines = (_) ->
     cancelJob: cancelJob
     importFiles: importFiles
     importSqlTable: importSqlTable
+    importBqTable: importBqTable
     setupParse: setupParse
     parseFiles: parseFiles
     createFrame: createFrame

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -13,6 +13,9 @@ _assistance =
   importFiles:
     description: 'Import file(s) into H<sub>2</sub>O'
     icon: 'files-o'
+  importSqlTable:
+    description: 'Import SQL table into H<sub>2</sub>O'
+    icon: 'table'
   getFrames:
     description: 'Get a list of frames in H<sub>2</sub>O'
     icon: 'table'
@@ -1492,6 +1495,23 @@ H2O.Routines = (_) ->
       else
         assist importFiles
 
+  extendImportSqlResults = (importResults) ->
+    render_ importResults, H2O.ImportSqlTableOutput, importResults
+
+  requestImportSqlTable = (arg, go) ->
+    _.requestImportSqlTable arg, (error, importResults) ->
+      if error
+        go error
+      else
+        go null, extendImportSqlResults importResults
+
+  importSqlTable = (arg) ->
+    switch typeOf arg
+      when 'Object'
+        _fork requestImportSqlTable, arg
+      else
+        assist importSqlTable
+
   extendParseSetupResults = (args, parseSetupResults) ->
     render_ parseSetupResults, H2O.SetupParseOutput, args, parseSetupResults
 
@@ -1896,6 +1916,8 @@ H2O.Routines = (_) ->
       switch func
         when importFiles
           _fork proceed, H2O.ImportFilesInput, []
+        when importSqlTable
+          _fork proceed, H2O.ImportSqlTableInput, args
         when buildModel
           _fork proceed, H2O.ModelInput, args
         when runAutoML
@@ -1988,6 +2010,7 @@ H2O.Routines = (_) ->
     getJob: getJob
     cancelJob: cancelJob
     importFiles: importFiles
+    importSqlTable: importSqlTable
     setupParse: setupParse
     parseFiles: parseFiles
     createFrame: createFrame

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -16,9 +16,6 @@ _assistance =
   importSqlTable:
     description: 'Import SQL table into H<sub>2</sub>O'
     icon: 'table'
-  importBqTable:
-    description: 'Import BigQuery table into H<sub>2</sub>O'
-    icon: 'table'
   getFrames:
     description: 'Get a list of frames in H<sub>2</sub>O'
     icon: 'table'

--- a/src/ext/modules/util.coffee
+++ b/src/ext/modules/util.coffee
@@ -167,6 +167,18 @@ columnLabelsFromFrame = (frame) ->
 
   columnLabels
 
+key = [64, 14, 190, 99, 77, 107, 95, 26, 211, 235, 41, 125, 110, 237, 151, 148]
+encryptPassword = (password) ->
+  aesCtr = new aesjs.ModeOfOperation.ctr key, new aesjs.Counter 5;
+  passwordBytes = aesjs.utils.utf8.toBytes password
+  encryptedBytes = aesCtr.encrypt passwordBytes
+  aesjs.utils.hex.fromBytes encryptedBytes
+
+decryptPassword = (encrypted) ->
+  aesCtr = new aesjs.ModeOfOperation.ctr key, new aesjs.Counter 5;
+  encryptedBytes = aesjs.utils.hex.toBytes encrypted
+  passwordBytes = aesCtr.decrypt encryptedBytes
+  aesjs.utils.utf8.fromBytes passwordBytes
 
 H2O.Util =
   validateFileExtension: validateFileExtension
@@ -174,3 +186,5 @@ H2O.Util =
   createListControl: createListControl
   createControl: createControl
   columnLabelsFromFrame: columnLabelsFromFrame
+  encryptPassword: encryptPassword
+  decryptPassword: decryptPassword


### PR DESCRIPTION
This PR exposes [ImportSqlTable](http://s3.amazonaws.com/h2o-release/h2o/master/3689/docs-website/h2o-docs/rest-api-reference.html#route-%2F99%2FImportSQLTable) endpoint in Flow UI. 

BigQuery widget works only if [Simba JDBC driver](https://cloud.google.com/bigquery/partners/simba-drivers/) is attached, thus the last commit hides it from menu and assistance, but it still can be used typing `importBqTable` in the cell.

Contributed by @Tapad.