### PR TITLE
[PUBDEV-5452] Adding exporting model as MOJO button

### DIFF
--- a/src/ext/components/export-model-input.coffee
+++ b/src/ext/components/export-model-input.coffee
@@ -1,18 +1,32 @@
 H2O.ExportModelInput = (_, _go, modelKey, path, opt={}) ->
   _models = signal []
+  _rawModels = signal []
   _selectedModelKey = signal null
-  _path = signal null 
+  _path = signal null
   _overwrite = signal if opt.overwrite then yes else no
+  _hasMojo = lift _selectedModelKey, (modelKey) ->
+    for model in _rawModels
+      if model.model_id.name == modelKey and model.have_mojo == true
+          return true
+    return false
+
   _canExportModel = lift _selectedModelKey, _path, (modelKey, path) -> modelKey and path
 
-  exportModel = ->
-    _.insertAndExecuteCell 'cs', "exportModel #{stringify _selectedModelKey()}, #{stringify _path()}, overwrite: #{if _overwrite() then 'true' else 'false'}"
+  _canExportModelMojo = lift _canExportModel, _hasMojo, (exportable, hasMojo) -> exportable and hasMojo
+
+  _export = (format) ->
+    _.insertAndExecuteCell 'cs', "exportModel #{stringify _selectedModelKey()}, #{stringify _path()}, overwrite: #{if _overwrite() then 'true' else 'false'}, format: \"#{ format }\""
+
+  exportModel = -> _export "bin"
+
+  exportModelMojo = -> _export "mojo"
 
   _.requestModels (error, models) ->
     if error
       #TODO handle properly
     else
       _models (model.model_id.name for model in models)
+      _rawModels = models
       _selectedModelKey modelKey
 
   defer _go
@@ -22,6 +36,8 @@ H2O.ExportModelInput = (_, _go, modelKey, path, opt={}) ->
   path: _path
   overwrite: _overwrite
   canExportModel: _canExportModel
+  canExportModelMojo: _canExportModelMojo
   exportModel: exportModel
+  exportModelMojo: exportModelMojo
   template: 'flow-export-model-input'
 

--- a/src/ext/components/export-model-input.coffee
+++ b/src/ext/components/export-model-input.coffee
@@ -5,7 +5,7 @@ H2O.ExportModelInput = (_, _go, modelKey, path, opt={}) ->
   _path = signal null
   _overwrite = signal if opt.overwrite then yes else no
   _hasMojo = lift _selectedModelKey, (modelKey) ->
-    for model in _rawModels
+    for model in _rawModels()
       if model.model_id.name == modelKey and model.have_mojo == true
           return true
     return false
@@ -26,7 +26,7 @@ H2O.ExportModelInput = (_, _go, modelKey, path, opt={}) ->
       #TODO handle properly
     else
       _models (model.model_id.name for model in models)
-      _rawModels = models
+      _rawModels models
       _selectedModelKey modelKey
 
   defer _go

--- a/src/ext/components/export-model-input.jade
+++ b/src/ext/components/export-model-input.jade
@@ -24,4 +24,9 @@
         button.flow-button(type='button' data-bind='click:exportModel, enable:canExportModel')
           i.fa.fa-save
           span Export
-
+    tr
+      th
+      td
+        button.flow-button(type='button' data-bind='click:exportModelMojo, enable:canExportModelMojo')
+          i.fa.fa-save
+          span Export Model Deployment Package (MOJO)

--- a/src/ext/modules/proxy.coffee
+++ b/src/ext/modules/proxy.coffee
@@ -358,8 +358,8 @@ H2O.Proxy = (_) ->
       force: overwrite
     doPost "/99/Models.bin/not_in_use", opts, go
 
-  requestExportModel = (key, path, overwrite, go) ->
-    doGet "/99/Models.bin/#{encodeURIComponent key}?dir=#{encodeURIComponent path}&force=#{overwrite}", go
+  requestExportModel = (format, key, path, overwrite, go) ->
+    doGet "/99/Models.#{format}/#{encodeURIComponent key}?dir=#{encodeURIComponent path}&force=#{overwrite}", go
 
   # TODO Obsolete
   requestModelBuildersVisibility = (go) ->

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -1405,7 +1405,7 @@ H2O.Routines = (_) ->
     render_ result, H2O.ExportModelOutput, result
 
   requestExportModel = (modelKey, path, opts, go) ->
-    _.requestExportModel modelKey, path, (if opts.overwrite then yes else no), (error, result) ->
+    _.requestExportModel opts.format, modelKey, path, (if opts.overwrite then yes else no), (error, result) ->
       if error then go error else go null, extendExportModel result
 
   exportModel = (modelKey, path, opts) ->


### PR DESCRIPTION
Adds new button in `Export Model` widget: `Export MOJO`.
Contributed by @Tapad

PS. You don't need to copy this branch into `h2oai` since users with write access to h2oai/h2o-flow can add new commits to this `export-mojo` branch.