### PR TITLE
[PUBDEV-5555] Fix incorrect clipping of tooltip.

### DIFF
--- a/src/flow.styl
+++ b/src/flow.styl
@@ -563,10 +563,11 @@ table
 .flow-plot
   monospace()
   overflow visible
-  max-height: 500px
-  overflow: auto
   margin-bottom 20px
   table
+    display: block
+    max-height: 500px
+    overflow: auto
     // margin 10px 0 20px 0
     font-size 85%
     tr:nth-child(odd)
@@ -594,6 +595,7 @@ table
 
   // Nasty hacks - FIXME
   .lz-tooltip
+    z-index 1
     table
       margin 0 !important
       font-size 100% !important


### PR DESCRIPTION
For example in case of column summary -> Summary.

**Before:**
![image](https://user-images.githubusercontent.com/29674210/40172063-891391ac-59cd-11e8-8e65-8784596820f1.png)

**After:**
<img width="410" alt="image" src="https://user-images.githubusercontent.com/29674210/40172052-810459f6-59cd-11e8-8823-e9c5d4324706.png">
