### PR TITLE
[PUBDEV-5601] Make 'Exclude these algorithms' always visible.

### DIFF
--- a/src/ext/components/automodel-input.coffee
+++ b/src/ext/components/automodel-input.coffee
@@ -36,9 +36,9 @@ H2O.AutoModelInput = (_, _go, opts={}) ->
 
   _excludeAlgosControl = H2O.Util.createListControl({
       name: 'exclude_algos',
-      label: 'Exclude Algorithms',
+      label: 'Exclude these algorithms',
       required: no,
-      grodable: no
+      gridable: no
   })
   excludeAlgosValues = [{value: 'GLM'}, {value: 'DRF'}, {value: 'GBM'}, {value: 'DeepLearning'}, {value: 'StackedEnsemble'}]
   _excludeAlgosControl.values excludeAlgosValues

--- a/src/ext/components/automodel-input.jade
+++ b/src/ext/components/automodel-input.jade
@@ -76,7 +76,7 @@
           label Leaderboard Frame:
         td
           select(data-bind="options:leaderboardFrames, value:leaderboardFrame, optionsCaption:'(Select)'")
-
+      // /ko
       tr
         // ko with:excludeAlgosControl
         th
@@ -95,7 +95,6 @@
                 // /ko
 
         // /ko
-      // /ko
       tr
         th
           label Max models to build:
@@ -118,7 +117,7 @@
           input(data-bind="value:stoppingRounds")
       tr
         th
-          label Stopping Tolerance:
+          label Early stopping tolerance:
         td
           input(data-bind="value:stoppingTolerance")
       tr


### PR DESCRIPTION
Exclude these algorithms should be visible even if training frame is not yet selected.

Minor fixes:
Fix typo.
Change labels.