### PR TITLE
PUBDEV-5679 - Create Flow equivalent of Python API's h2o.import_sql_s…

### DIFF
--- a/src/ext/components/import-sql-table-input.coffee
+++ b/src/ext/components/import-sql-table-input.coffee
@@ -7,6 +7,10 @@ H2O.ImportSqlTableInput = (_, _go) ->
   _exception = signal ''
   _hasErrorMessage = lift _exception, (exception) -> if exception then yes else no
 
+  # This is a shim for ko binding handlers to attach methods to
+  # The ko 'autoResize' custom binding attaches an autoResize() method to this.
+  _actions = {}
+
   importSqlTableAction = ->
     encryptedPassword = H2O.Util.encryptPassword _specifiedPassword()
 
@@ -32,5 +36,7 @@ H2O.ImportSqlTableInput = (_, _go) ->
   specifiedUsername: _specifiedUsername
   specifiedPassword: _specifiedPassword
   exception: _exception
+  _actions: _actions
+  autoResize: -> _actions.autoResize()
   importSqlTableAction: importSqlTableAction
   template: 'flow-import-sql-table-input'

--- a/src/ext/components/import-sql-table-input.coffee
+++ b/src/ext/components/import-sql-table-input.coffee
@@ -12,10 +12,15 @@ H2O.ImportSqlTableInput = (_, _go) ->
 
     opt =
        connection_url: _specifiedUrl()
-       table: _specifiedTable()
        columns: _specifiedColumns()
        username: _specifiedUsername()
        password: encryptedPassword
+
+    if _specifiedTable().trim().toLowerCase().startsWith("select")
+      opt.select_query = _specifiedTable().trim()
+    else
+      opt.table = _specifiedTable()
+
     _.insertAndExecuteCell 'cs', "importSqlTable #{ stringify opt }"
 
   defer _go

--- a/src/ext/components/import-sql-table-input.jade
+++ b/src/ext/components/import-sql-table-input.jade
@@ -19,7 +19,7 @@
             tbody
               tr
                 td.flow-wide
-                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedTable" placeholder='Enter a name of SQL table or SQL SELECT query.')
+                  textarea.flow-textbox(type='textarea' style='width:100%; padding: 0px; margin: 0px;' data-bind="value:specifiedTable, autoResize:_actions" placeholder='Enter a name of SQL table or SQL SELECT query.' rows='1')
       tr
         th(width='125') Columns:
         td

--- a/src/ext/components/import-sql-table-input.jade
+++ b/src/ext/components/import-sql-table-input.jade
@@ -13,13 +13,13 @@
                 td.flow-wide
                   input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedUrl" placeholder='Enter URL of the SQL database as specified by the JDBC.')
       tr
-        th(width='125') Table:
+        th(width='125') Table/SQL Select:
         td
           table(width='100%')
             tbody
               tr
                 td.flow-wide
-                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedTable" placeholder='Enter a name of SQL table.')
+                  input.flow-textbox(type='text' style='width:100%' data-bind="value:specifiedTable" placeholder='Enter a name of SQL table or SQL SELECT query.')
       tr
         th(width='125') Columns:
         td

--- a/src/ext/modules/proxy.coffee
+++ b/src/ext/modules/proxy.coffee
@@ -258,6 +258,7 @@ H2O.Proxy = (_) ->
     opts =
       connection_url: args.connection_url
       table: args.table
+      select_query: args.select_query
       username: args.username
       password: decryptedPassword
     if args.columns != ''


### PR DESCRIPTION
…elect

[PUBDEV-5679](https://0xdata.atlassian.net/browse/PUBDEV-5679)

- One input field for either table name or SQL select query to fill
- Anything starting with "select" is considered to be a SELECT statement
- Detectio of SELECT is case insensitive and the input is properly trimmed `_specifiedTable().trim().toLowerCase().startsWith("select")`

Here you can see it in action. `SELECT`, `select`, `sElect`, `SeLECT` ... everything works as planned

![snimek z 2018-06-25 08-49-22](https://user-images.githubusercontent.com/8769110/41834891-01b71eca-7856-11e8-816c-5cc8b5174471.png)
