### PR TITLE
PUBDEV-6005: added XGBoost to list of algos that can be excluded in Flow

### DIFF
--- a/src/ext/components/automodel-input.coffee
+++ b/src/ext/components/automodel-input.coffee
@@ -46,7 +46,7 @@ H2O.AutoModelInput = (_, _go, opts={}) ->
       required: no,
       gridable: no
   })
-  excludeAlgosValues = [{value: 'GLM'}, {value: 'DRF'}, {value: 'GBM'}, {value: 'DeepLearning'}, {value: 'StackedEnsemble'}]
+  excludeAlgosValues = [{value: 'GLM'}, {value: 'DRF'}, {value: 'GBM'}, {value: 'XGBoost'}, {value: 'DeepLearning'}, {value: 'StackedEnsemble'}]
   _excludeAlgosControl.values excludeAlgosValues
 
   defaultNfolds = 5


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6005

added XGBoost to list of algos that can be excluded in flow (quick static fix for now)