### PR TITLE
[webpack] disable sourcemaps by default

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -11,7 +11,6 @@ packageJson = require('./package.json');
 config =
   context: path.resolve __dirname, 'src'
   entry: './index.coffee'
-  devtool: 'inline-source-map'
   devServer: {
     contentBase: './build'
   }


### PR DESCRIPTION
- they bloat up the bundle, unnecessary in production
- in development mode sourcemap are available by default