### PR TITLE
[build] remove symlinking of preinstalled npm deps

### DIFF
--- a/docker/scripts/warmup_caches
+++ b/docker/scripts/warmup_caches
@@ -10,12 +10,11 @@ fi
 cd ~
 
 git clone https://github.com/h2oai/h2o-flow
+
 cd h2o-flow
+
 git checkout ${H2O_BRANCH}
-mkdir -p /home/jenkins/flow-cache/node_modules /home/jenkins/flow-cache/lib
-ln -s /home/jenkins/flow-cache/node_modules .
-
 make install
-cd ..
 
+cd ..
 rm -rf h2o-flow

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -86,9 +86,6 @@ try {
                                 sh """
                                     env
                                     id
-
-                                    ln -s /home/jenkins/flow-cache/node_modules/ ./node_modules
-
                                     sed -E "s/.+version.+/  \\"version\\": \\"$flowVersion\\",/" package.json > package.json.tmp && mv package.json.tmp package.json
                                     make install build
                                 """


### PR DESCRIPTION
- this breaks npm for some reason
- it is enough that npms are cached in ~/.npm