### PR TITLE
PUBDEV-6601 (yates): adding missing AutoML properties in Flow to reflect latest changes

### DIFF
--- a/src/ext/components/automodel-input.coffee
+++ b/src/ext/components/automodel-input.coffee
@@ -10,6 +10,8 @@ module.exports = (_, _go, opts={}) ->
   _trainingFrame = signal null
   _validationFrames = signal []
   _validationFrame = signal null
+  _blendingFrames = signal []
+  _blendingFrame = signal null
   _leaderboardFrames = signal []
   _leaderboardFrame = signal null
   _hasTrainingFrame = lift _trainingFrame, (frame) -> if frame then yes else no
@@ -26,6 +28,8 @@ module.exports = (_, _go, opts={}) ->
   _maxModels = signal ''
   defaultMaxRunTime = 3600
   _maxRuntimeSecs = signal defaultMaxRunTime
+  defaultMaxRunTimePerModel = 0
+  _maxRuntimeSecsPerModel = signal defaultMaxRunTimePerModel
   _stoppingMetrics = signal []
   _stoppingMetric = signal null
   _sortMetrics = signal []
@@ -76,6 +80,10 @@ module.exports = (_, _go, opts={}) ->
     unless isNaN parsed = parseInt _maxRuntimeSecs(), 10
       maxRuntimeSecs = parsed
 
+    maxRuntimeSecsPerModel = defaultMaxRunTimePerModel
+    unless isNaN parsed = parseInt _maxRuntimeSecsPerModel(), 10
+      maxRuntimeSecsPerModel = parsed
+
     stoppingRounds = defaultStoppingRounds
     unless isNaN parsed = parseInt _stoppingRounds(), 10
       stoppingRounds = parsed
@@ -112,10 +120,12 @@ module.exports = (_, _go, opts={}) ->
       fold_column: _foldColumn()
       weights_column: _weightsColumn()
       validation_frame: _validationFrame()
+      blending_frame: _blendingFrame()
       leaderboard_frame: _leaderboardFrame()
       seed: seed
       max_models: maxModels
       max_runtime_secs: maxRuntimeSecs
+      max_runtime_secs_per_model: maxRuntimeSecsPerModel
       stopping_metric: _stoppingMetric()
       sort_metric: sortMetric
       stopping_rounds: stoppingRounds
@@ -142,11 +152,14 @@ module.exports = (_, _go, opts={}) ->
       frames = (frame.frame_id.name for frame in frames when not frame.is_text)
       _trainingFrames frames
       _validationFrames frames
+      _blendingFrames frames
       _leaderboardFrames frames
       if opts.training_frame
         _trainingFrame opts.training_frame
       if opts.validation_frame
         _validationFrame opts.validation_frame
+      if opts.blending_frame
+        _blendingFrame opts.blending_frame
       if opts.leaderboard_frame
         _leaderboardFrame opts.leaderboard_frame
 
@@ -189,6 +202,8 @@ module.exports = (_, _go, opts={}) ->
   hasTrainingFrame: _hasTrainingFrame
   validationFrames: _validationFrames
   validationFrame: _validationFrame
+  blendingFrames: _blendingFrames
+  blendingFrame: _blendingFrame
   leaderboardFrames: _leaderboardFrames
   leaderboardFrame: _leaderboardFrame
   columns: _columns
@@ -198,6 +213,7 @@ module.exports = (_, _go, opts={}) ->
   seed: _seed
   maxModels: _maxModels
   maxRuntimeSecs: _maxRuntimeSecs
+  maxRuntimeSecsPerModel: _maxRuntimeSecsPerModel
   stoppingMetrics: _stoppingMetrics
   stoppingMetric: _stoppingMetric
   sortMetrics: _sortMetrics

--- a/src/ext/components/automodel-input.pug
+++ b/src/ext/components/automodel-input.pug
@@ -73,6 +73,11 @@
           select(data-bind="options:validationFrames, value:validationFrame, optionsCaption:'(Select)'")
       tr
         th
+          label Blending Frame:
+        td
+          select(data-bind="options:blendingFrames, value:blendingFrame, optionsCaption:'(Select)'")
+      tr
+        th
           label Leaderboard Frame:
         td
           select(data-bind="options:leaderboardFrames, value:leaderboardFrame, optionsCaption:'(Select)'")
@@ -122,6 +127,11 @@
           label Max Run Time (sec):
         td
           input(data-bind="value:maxRuntimeSecs")
+      tr
+        th
+          label Max Run Time Per Model (sec):
+        td
+          input(data-bind="value:maxRuntimeSecsPerModel")
       tr
         th
           label Early stopping metric:

--- a/src/ext/modules/routines.coffee
+++ b/src/ext/modules/routines.coffee
@@ -1610,6 +1610,7 @@ exports.init = (_) ->
       input_spec:
         training_frame: opts.training_frame
         validation_frame: opts.validation_frame
+        blending_frame: opts.blending_frame
         response_column: opts.response_column
         fold_column: opts.fold_column
         weights_column: opts.weights_column
@@ -1631,6 +1632,7 @@ exports.init = (_) ->
           seed: opts.seed
           max_models: opts.max_models
           max_runtime_secs: opts.max_runtime_secs
+          max_runtime_secs_per_model: opts.max_runtime_secs_per_model
           stopping_rounds: opts.stopping_rounds
           stopping_tolerance: opts.stopping_tolerance
           # TODO Enums currently fail with:


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6601

adding 2 automl fields: blending-frame and max-runtime-per-model
(cherry picked from commit e846ee7c1719cf1ee88e1da0f67b5cdd2f3c15a5)


