### PR TITLE
[PUBDEV-6868] Flow does not respect context path of encapsulating environment

### DIFF
--- a/src/core/flow.coffee
+++ b/src/core/flow.coffee
@@ -15,11 +15,15 @@ h2oApplication = require('../ext/modules/application')
 ko = require('./modules/knockout')
 
 getContextPath = (_) ->
-    url = window.location.toString()
-    parts = url.split('/')
-    # remove flow/index.html from end of the URL
-    contextPathParts = parts.splice(0, parts.length - 2)
-    _.ContextPath = contextPathParts.join('/')
+    if process.env.NODE_ENV == "development"
+      console.debug "Development mode, using localhost:54321"
+      _.ContextPath = "http://localhost:54321/"
+    else
+      url = window.location.toString()
+      parts = url.split('/')
+      # remove flow/index.html from end of the URL
+      contextPathParts = parts.splice(0, parts.length - 2)
+      _.ContextPath = contextPathParts.join('/')
 
 checkSparklingWater = (context) ->
     context.onSparklingWater = false


### PR DESCRIPTION
Thanks fix ensures that Flow can run correctly run in environments which already have some their own context path, such as Azure.

@mmalohlava with this fix, we can run SW on Azure DBC on the port 9009 